### PR TITLE
Fix EDF scheduler cancellation and state visibility

### DIFF
--- a/src/main/java/ca/spottedleaf/concurrentutil/numa/LinuxNuma.java
+++ b/src/main/java/ca/spottedleaf/concurrentutil/numa/LinuxNuma.java
@@ -70,6 +70,9 @@ public final class LinuxNuma extends OSNuma.PreCalculatedNuma {
                                 break core_to_numa_setup;
                             }
                             // it is set, so mark it in the core mapping
+                            if (coreToNuma.length <= cpu) {
+                                coreToNuma = Arrays.copyOf(coreToNuma, cpu + 1);
+                            }
                             coreToNuma[cpu] = node;
                         }
                     }

--- a/src/main/java/ca/spottedleaf/concurrentutil/scheduler/EDFSchedulerThreadPool.java
+++ b/src/main/java/ca/spottedleaf/concurrentutil/scheduler/EDFSchedulerThreadPool.java
@@ -226,6 +226,10 @@ public final class EDFSchedulerThreadPool extends Scheduler {
     @Override
     public void schedule(final SchedulableTick task) {
         synchronized (this.scheduleLock) {
+            if (task.getScheduledStart() == TimeUtil.DEADLINE_NOT_SET) {
+                throw new IllegalStateException("Start must be set when scheduling");
+            }
+
             final ScheduledState state = new ScheduledState(task);
             if (!task.setState(state)) {
                 throw new IllegalStateException("Task " + task + " is already scheduled or cancelled");
@@ -284,15 +288,18 @@ public final class EDFSchedulerThreadPool extends Scheduler {
 
     @Override
     public boolean cancel(final SchedulableTick task) {
-        if (!(task.state instanceof ScheduledState state)) {
-            return false;
-        }
-
-        if (state.schedulerOwnedBy != this) {
+        if (!(task.getState() instanceof ScheduledState state)) {
             return false;
         }
 
         synchronized (this.scheduleLock) {
+            if (state.schedulerOwnedBy != this) {
+                return false;
+            }
+            if (!state.tryMarkCancelled()) {
+                return false;
+            }
+
             if (this.queued.remove(state)) {
                 // cancelled, and no runner owns it - so return
                 return true;
@@ -315,8 +322,8 @@ public final class EDFSchedulerThreadPool extends Scheduler {
                 return true;
             }
 
-            // could not find it in queue
-            return false;
+            // the task may currently be running; cancellation is applied by state transition
+            return true;
         }
     }
 

--- a/src/main/java/ca/spottedleaf/concurrentutil/scheduler/EDFSchedulerThreadPool.java
+++ b/src/main/java/ca/spottedleaf/concurrentutil/scheduler/EDFSchedulerThreadPool.java
@@ -322,8 +322,8 @@ public final class EDFSchedulerThreadPool extends Scheduler {
                 return true;
             }
 
-            // the task may currently be running; cancellation is applied by state transition
-            return true;
+            // could not find it in queue
+            return false;
         }
     }
 

--- a/src/main/java/ca/spottedleaf/concurrentutil/scheduler/SchedulableTick.java
+++ b/src/main/java/ca/spottedleaf/concurrentutil/scheduler/SchedulableTick.java
@@ -32,7 +32,11 @@ public abstract class SchedulableTick {
 
     long scheduledStart = TimeUtil.DEADLINE_NOT_SET;
 
-    Object state;
+    private volatile Object state;
+
+    final Object getState() {
+        return this.state;
+    }
 
     boolean setState(final Object state) {
         synchronized (this) {
@@ -79,7 +83,7 @@ public abstract class SchedulableTick {
     public String toString() {
         return "SchedulableTick:{" +
                 "class=" + this.getClass().getName() + "," +
-                "state=" + this.state + ","
+                "state=" + this.getState() + ","
                 + "}";
     }
 }

--- a/src/main/java/ca/spottedleaf/concurrentutil/scheduler/StealingScheduledThreadPool.java
+++ b/src/main/java/ca/spottedleaf/concurrentutil/scheduler/StealingScheduledThreadPool.java
@@ -68,7 +68,7 @@ public final class StealingScheduledThreadPool extends Scheduler {
     }
 
     private static ScheduledState getState(final SchedulableTick tick) {
-        return (ScheduledState)tick.state;
+        return (ScheduledState)tick.getState();
     }
 
     private static Thread[] getThreads(final COWArrayList<TickThreadRunner> runners) {
@@ -274,7 +274,8 @@ public final class StealingScheduledThreadPool extends Scheduler {
             int selectedSize = Integer.MAX_VALUE;
 
             for (final NodeThreads node : nodes) {
-                final int distance = this.numa.getNumaDistance(currentNode, node.nodeNumber);
+                final int rawDistance = this.numa.getNumaDistance(currentNode, node.nodeNumber);
+                final int distance = rawDistance <= 0 ? Integer.MAX_VALUE : rawDistance;
                 if (distance > selectedDistance) {
                     continue;
                 }
@@ -298,7 +299,8 @@ public final class StealingScheduledThreadPool extends Scheduler {
             int selectedDistance = Integer.MAX_VALUE;
 
             for (final NodeThreads node : nodes) {
-                final int distance = this.numa.getNumaDistance(currentNode, node.nodeNumber);
+                final int rawDistance = this.numa.getNumaDistance(currentNode, node.nodeNumber);
+                final int distance = rawDistance <= 0 ? Integer.MAX_VALUE : rawDistance;
                 for (final TickThreadRunner runner : node.threads) {
                     // yes the size is just a rough guess...
                     final int size = runner.tickQueue.size();
@@ -350,14 +352,14 @@ public final class StealingScheduledThreadPool extends Scheduler {
 
     @Override
     public void notifyTasks(final SchedulableTick tick) {
-        if (tick.state instanceof ScheduledState state) {
+        if (tick.getState() instanceof ScheduledState state) {
             state.scheduleTasks();
         }
     }
 
     @Override
     public boolean cancel(final SchedulableTick tick) {
-        if (tick.state instanceof ScheduledState state) {
+        if (tick.getState() instanceof ScheduledState state) {
             return state.tryCancel();
         } else {
             return false;
@@ -915,7 +917,8 @@ public final class StealingScheduledThreadPool extends Scheduler {
             TickThreadRunner selectedRunner = null;
 
             for (final NodeThreads node : this.nodes) {
-                final int distance = this.scheduler.numa.getNumaDistance(this.node.nodeNumber, node.nodeNumber);
+                final int rawDistance = this.scheduler.numa.getNumaDistance(this.node.nodeNumber, node.nodeNumber);
+                final int distance = rawDistance <= 0 ? Integer.MAX_VALUE : rawDistance;
 
                 for (final TickThreadRunner runner : node.threads) {
                     if (runner == this) {


### PR DESCRIPTION
This PR fixes a few correctness issues in the EDF scheduler.

- Make `SchedulableTick.state` volatile, it was read without synchronization
- Throw in `EDFSchedulerThreadPool.schedule()` when the start is not set, as documented in `Scheduler#schedule`
- Apply the cancelled state in `EDFSchedulerThreadPool.cancel()` so a task cancelled while its tick is running is not rescheduled