### PR TITLE
Fix inverted value comparison logic in `equals` for `SWMRHashTable` and `SWMRLong2ObjectHashTable`

### DIFF
--- a/src/main/java/ca/spottedleaf/concurrentutil/map/SWMRHashTable.java
+++ b/src/main/java/ca/spottedleaf/concurrentutil/map/SWMRHashTable.java
@@ -260,7 +260,7 @@ public class SWMRHashTable<K, V> implements Map<K, V>, Iterable<Map.Entry<K, V>>
                 final V value = curr.getValueAcquire();
 
                 final Object otherValue = other.get(curr.key);
-                if (otherValue == null || (value != otherValue && value.equals(otherValue))) {
+                if (otherValue == null || (value != otherValue && !value.equals(otherValue))) {
                     return false;
                 }
             }

--- a/src/main/java/ca/spottedleaf/concurrentutil/map/SWMRLong2ObjectHashTable.java
+++ b/src/main/java/ca/spottedleaf/concurrentutil/map/SWMRLong2ObjectHashTable.java
@@ -237,7 +237,7 @@ public class SWMRLong2ObjectHashTable<V> {
                 final V value = curr.getValueAcquire();
 
                 final Object otherValue = other.get(curr.key);
-                if (otherValue == null || (value != otherValue && value.equals(otherValue))) {
+                if (otherValue == null || (value != otherValue && !value.equals(otherValue))) {
                     return false;
                 }
             }


### PR DESCRIPTION
Resolves #8 

Currently, equal objects with different references cause `equals` to return
`false`, while non-equal non-null objects are accepted as equal.