### PR TITLE
Fix LinkedIterator.remove() for the last live element

### DIFF
--- a/src/main/java/ca/spottedleaf/concurrentutil/collection/MultiThreadedQueue.java
+++ b/src/main/java/ca/spottedleaf/concurrentutil/collection/MultiThreadedQueue.java
@@ -1368,6 +1368,7 @@ public class MultiThreadedQueue<E> implements Queue<E> {
 
             /* out of nodes to iterate */
             /* keep curr for remove() calls */
+            this.curr = this.next;
             this.next = null;
             this.nextElement = null;
         }


### PR DESCRIPTION
LinkedIterator.findNext() updates `curr` only when it finds another live node. When next() returns the last live element, `curr` remains null or points to the previously returned node, causing the iterator to remove the wrong element.

### Logs

Exception found on Paper: https://mclo.gs/SlxTMFc

### Minimal reproduce code

```java
public void wwwwwwwww() {
    MultiThreadedQueue<String> queue = new MultiThreadedQueue<>(List.of("A"));
    Iterator<String> itr = queue.iterator();
  
    itr.next(); // A
    itr.remove(); // IllegalStateException
}
```

### Fix

Record the current `next` node before clearing the final iterator state. This maintains exact-node O(1) removal and keeps MTQueue's concurrent semantics.